### PR TITLE
수정.  가드 기반의 선언적 인증 시스템 리팩토링

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { ClassSerializerInterceptor, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -10,6 +10,11 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { LogsModule } from './logs/logs.module';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import {
+  AccessTokenGuard,
+  RefreshTokenGuard,
+} from './auth/guard/bearer-token.guard';
 
 @Module({
   imports: [
@@ -42,6 +47,22 @@ import { LogsModule } from './logs/logs.module';
     AuthModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    //interceptor: use ClassSerializerInterceptor to transfer DTO
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ClassSerializerInterceptor,
+    },
+    //guard: authentication and authorization
+    {
+      provide: APP_GUARD,
+      useClass: AccessTokenGuard,
+    },
+    // TODO. implement rolesGuard
+    // {
+    //   provide: APP_GUARD, useClass: RolesGuard
+    // }
+  ],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,13 +1,30 @@
-import { Controller, Post, Headers, Req, Body } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Headers,
+  Req,
+  Body,
+  UseGuards,
+  Get,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { Request } from 'express';
 import { RegisterUserDto } from './dto/register-user.dto';
+import { IsPublic } from '../common/decorator/is-public.decorator';
+import {
+  AccessTokenGuard,
+  RefreshTokenGuard,
+} from './guard/bearer-token.guard';
+import { User } from '../users/decorator/user.decorator';
+import { UsersModel } from '../users/entity/users.entity';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
+  @IsPublic()
+  @UseGuards(RefreshTokenGuard)
   async postLoginEmail(
     @Headers('authorization') rawToken: string,
     @Req() req: Request,
@@ -20,16 +37,21 @@ export class AuthController {
   }
 
   @Post('users')
+  @IsPublic()
   async postRegister(@Body() registerUserDto: RegisterUserDto) {
     return await this.authService.registerWithEmail(registerUserDto);
   }
 
   @Post('token/access')
+  @IsPublic()
+  @UseGuards(RefreshTokenGuard)
   async postTokenAccess(@Headers('authorization') rawToken: string) {
     return await this.reissueToken(rawToken, false);
   }
 
   @Post('token/refresh')
+  @IsPublic()
+  @UseGuards(RefreshTokenGuard)
   async postTokenRefresh(@Headers('authorization') rawToken: string) {
     return await this.reissueToken(rawToken, true);
   }
@@ -41,5 +63,12 @@ export class AuthController {
     const tokenType = isRefresh ? 'refreshToken' : 'accessToken';
 
     return { [tokenType]: newToken };
+  }
+
+  @Get('test/here')
+  @UseGuards(AccessTokenGuard)
+  async testHere(@User() user: UsersModel) {
+    console.log('testHere.user : ', user);
+    return user;
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -13,8 +13,8 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
-  @UseGuards(BasicTokenGuard)
   @IsPublic()
+  @UseGuards(BasicTokenGuard)
   async postLoginEmail(@User() user: UsersModel) {
     return this.authService.loginUser(user);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,10 +11,7 @@ import { AuthService } from './auth.service';
 import { Request } from 'express';
 import { RegisterUserDto } from './dto/register-user.dto';
 import { IsPublic } from '../common/decorator/is-public.decorator';
-import {
-  AccessTokenGuard,
-  RefreshTokenGuard,
-} from './guard/bearer-token.guard';
+import { RefreshTokenGuard } from './guard/bearer-token.guard';
 import { User } from '../users/decorator/user.decorator';
 import { UsersModel } from '../users/entity/users.entity';
 
@@ -24,7 +21,6 @@ export class AuthController {
 
   @Post('login')
   @IsPublic()
-  @UseGuards(RefreshTokenGuard)
   async postLoginEmail(
     @Headers('authorization') rawToken: string,
     @Req() req: Request,
@@ -66,9 +62,16 @@ export class AuthController {
   }
 
   @Get('test/here')
-  @UseGuards(AccessTokenGuard)
+  // @UseGuards(AccessTokenGuard)  // app.module 에서 전역으로 사용중임
   async testHere(@User() user: UsersModel) {
     console.log('testHere.user : ', user);
+    return user;
+  }
+
+  @Get('test/here2')
+  @IsPublic()
+  async testHere2(@User() user: UsersModel) {
+    console.log('its public. but... user : ', user);
     return user;
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -3,11 +3,12 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
 import { JwtModule } from '@nestjs/jwt';
+import { BasicTokenGuard } from './guard/basic-token.guard';
 
 @Module({
   imports: [UsersModule, JwtModule.register({})],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, BasicTokenGuard],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -158,6 +158,13 @@ export class AuthService {
     }
   }
 
+  async reissueToken(token: string, isRefresh: boolean) {
+    const newToken = await this.rotateToken(token, isRefresh);
+    const tokenType = isRefresh ? 'refreshToken' : 'accessToken';
+
+    return { [tokenType]: newToken };
+  }
+
   async rotateToken(token: string, isRefreshToken: boolean) {
     const decoded = this.jwtService.verify(token, {
       secret: this.jwtSecret,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -143,7 +143,7 @@ export class AuthService {
 
     return this.jwtService.sign(payload, {
       secret: this.jwtSecret,
-      // refresh: 7수저d, access: 1h
+      // refresh: 7d, access: 1h
       expiresIn: isRefreshToken ? '7d' : '1h',
     });
   }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -143,8 +143,8 @@ export class AuthService {
 
     return this.jwtService.sign(payload, {
       secret: this.jwtSecret,
-      // refresh: 1d, access: 1h
-      expiresIn: isRefreshToken ? 60 * 60 * 7 : 60 * 60,
+      // refresh: 7수저d, access: 1h
+      expiresIn: isRefreshToken ? '7d' : '1h',
     });
   }
 

--- a/backend/src/auth/decorator/token.decorator.ts
+++ b/backend/src/auth/decorator/token.decorator.ts
@@ -1,0 +1,21 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+export const Token = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+
+    const token = req.token;
+
+    if (!token) {
+      throw new InternalServerErrorException(
+        'Token decorator must be used with a guard that populates req.token.',
+      );
+    }
+
+    return token;
+  },
+);

--- a/backend/src/auth/dto/login-failed.dto.ts
+++ b/backend/src/auth/dto/login-failed.dto.ts
@@ -1,6 +1,13 @@
 import { UsersModel } from '../../users/entity/users.entity';
+import { IsIP, IsObject, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class LoginFailedDto {
+  @IsObject()
+  @ValidateNested()
+  @Type(() => UsersModel)
   user: UsersModel;
+
+  @IsIP()
   ip: string;
 }

--- a/backend/src/auth/dto/register-user.dto.ts
+++ b/backend/src/auth/dto/register-user.dto.ts
@@ -1,11 +1,54 @@
-import { PickType } from '@nestjs/swagger';
-import { UsersModel } from '../../users/entity/users.entity';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
-export class RegisterUserDto extends PickType(UsersModel, [
-  'username',
-  'email',
-  'password',
-  'profileImage',
-  'phoneNumber',
-  'region_id',
-]) {}
+/**
+ * Validates the data received from the client for user registration.
+ */
+export class RegisterUserDto {
+  /**
+   * The user's name.
+   * @example "user1"
+   */
+  @IsString({ message: 'Username must be a string.' })
+  @IsNotEmpty({ message: 'Username is required.' })
+  username: string;
+
+  /**
+   * The user's email, used for login.
+   * @example "user1@dummyUser.com"
+   */
+  @IsEmail({}, { message: 'Must be a valid email format.' })
+  @IsNotEmpty({ message: 'Email is required.' })
+  email: string;
+
+  /**
+   * The user's password.
+   * @example "user1"
+   */
+  @IsString({ message: 'Password must be a string.' })
+  @IsNotEmpty({ message: 'Password is required.' })
+  password: string;
+
+  /**
+   * The URL of the user's profile image (optional).
+   * @example "/images/profile.jpg"
+   */
+  @IsString({ message: 'Profile image URL must be a string.' })
+  @IsOptional()
+  profileImage?: string;
+
+  /**
+   * The user's phone number (optional).
+   * @example "010-1234-5678"
+   */
+  @IsString({ message: 'Phone number must be a string.' })
+  @IsOptional()
+  phoneNumber?: string;
+
+  /**
+   * The ID of the user's region (optional).
+   * @example "-"
+   */
+  @IsString({ message: 'Region ID must be a string.' })
+  @IsOptional()
+  region_id?: string;
+}

--- a/backend/src/auth/guard/basic-token.guard.ts
+++ b/backend/src/auth/guard/basic-token.guard.ts
@@ -1,0 +1,33 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class BasicTokenGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const rawToken = req.headers.authorization;
+
+    if (!rawToken) {
+      throw new UnauthorizedException('No Token Provided');
+    }
+
+    const token = this.authService.extractTokenFromHeader(rawToken, false);
+
+    const { email, password } = this.authService.decodedBasicToken(token);
+
+    req.user = await this.authService.authenticateWithEmailAndPassword(
+      { email, password },
+      req.ip,
+    );
+
+    return true;
+  }
+}

--- a/backend/src/auth/guard/bearer-token.guard.ts
+++ b/backend/src/auth/guard/bearer-token.guard.ts
@@ -1,0 +1,89 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../../common/decorator/is-public.decorator';
+import { AuthService } from '../auth.service';
+import { UsersService } from '../../users/users.service';
+
+@Injectable()
+export class BearerTokenGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly authService: AuthService,
+    private readonly userService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (isPublic) {
+      req.isRouterPublic = true;
+      return true;
+    }
+
+    const rawToken = req.headers.authorization;
+
+    if (!rawToken) {
+      throw new UnauthorizedException('No Token Provided');
+    }
+
+    const token = this.authService.extractTokenFromHeader(rawToken, true);
+
+    const result = await this.authService.verifyToken(token);
+
+    const user = await this.userService.getUserByEmail(result.email);
+
+    req.user = user;
+    req.token = token;
+    req.tokenType = result.type;
+
+    return true;
+  }
+}
+
+@Injectable()
+export class AccessTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.isRouterPublic) {
+      return true;
+    }
+
+    if (req.tokenType !== 'access') {
+      throw new UnauthorizedException('No Access Token Provided');
+    }
+
+    return true;
+  }
+}
+
+@Injectable()
+export class RefreshTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.isRouterPublic) {
+      return true;
+    }
+
+    if (req.tokenType !== 'refresh') {
+      throw new UnauthorizedException('No Refresh Token Provided');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/guard/bearer-token.guard.ts
+++ b/backend/src/auth/guard/bearer-token.guard.ts
@@ -84,6 +84,8 @@ export class AccessTokenGuard extends BearerTokenGuard {
 @Injectable()
 export class RefreshTokenGuard extends BearerTokenGuard {
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
     const req = context.switchToHttp().getRequest();
 
     if (req.tokenType !== 'refresh') {

--- a/backend/src/auth/guard/bearer-token.guard.ts
+++ b/backend/src/auth/guard/bearer-token.guard.ts
@@ -84,16 +84,12 @@ export class AccessTokenGuard extends BearerTokenGuard {
 @Injectable()
 export class RefreshTokenGuard extends BearerTokenGuard {
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    await super.canActivate(context);
-
     const req = context.switchToHttp().getRequest();
 
-    if (req.isRouterPublic) {
-      return true;
-    }
-
     if (req.tokenType !== 'refresh') {
-      throw new UnauthorizedException('No Refresh Token Provided');
+      throw new UnauthorizedException(
+        'Invalid Token Type. Refresh Token is required.',
+      );
     }
 
     return true;

--- a/backend/src/common/decorator/is-public.decorator.ts
+++ b/backend/src/common/decorator/is-public.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'is_public';
+
+export const IsPublic = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,9 +3,10 @@ import { AppModule } from './app.module';
 import * as process from 'node:process';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   app.setGlobalPrefix('api');
 
@@ -34,6 +35,8 @@ async function bootstrap() {
   // Swagger UI 경로 설정
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  app.set('trust proxy', true);
 
   await app.listen(3000);
 }

--- a/backend/src/users/decorator/user.decorator.ts
+++ b/backend/src/users/decorator/user.decorator.ts
@@ -12,9 +12,12 @@ export const User = createParamDecorator(
     const user = req.user as UsersModel;
 
     if (!user) {
-      throw new InternalServerErrorException(
-        'User Decorator must be used with an accessTokenGuard',
-      );
+      if (!req.isRouterPublic) {
+        throw new InternalServerErrorException(
+          'User decorator cannot be used on a protected route without an authentication guard.',
+        );
+      }
+      return null;
     }
 
     if (data) {

--- a/backend/src/users/decorator/user.decorator.ts
+++ b/backend/src/users/decorator/user.decorator.ts
@@ -1,0 +1,26 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { UsersModel } from '../entity/users.entity';
+
+export const User = createParamDecorator(
+  (data: keyof UsersModel | undefined, context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+
+    const user = req.user as UsersModel;
+
+    if (!user) {
+      throw new InternalServerErrorException(
+        'User Decorator must be used with an accessTokenGuard',
+      );
+    }
+
+    if (data) {
+      return user[data];
+    }
+
+    return user;
+  },
+);

--- a/backend/src/users/entity/users.entity.ts
+++ b/backend/src/users/entity/users.entity.ts
@@ -10,18 +10,12 @@ import { ProductModel } from '../../product/entity/product.entity';
 
 @Entity()
 export class UsersModel extends BaseModel {
-  @IsString()
-  @IsNotEmpty()
   @Column({ type: 'varchar', length: 50, nullable: false })
   username: string;
 
-  @IsEmail()
-  @IsNotEmpty()
   @Column({ type: 'varchar', length: 255, unique: true, nullable: false })
   email: string;
 
-  @IsString()
-  @IsNotEmpty()
   @Column({
     name: 'password_hash',
     type: 'varchar',
@@ -31,18 +25,12 @@ export class UsersModel extends BaseModel {
   @Exclude({ toPlainOnly: true })
   password: string;
 
-  @IsString()
-  @IsOptional()
   @Column({ name: 'profile_image', type: 'text', nullable: true })
   profileImage: string;
 
-  @IsString()
-  @IsOptional()
   @Column({ name: 'phone_number', type: 'varchar', length: 20, nullable: true })
   phoneNumber: string;
 
-  @IsString()
-  @IsOptional()
   @OneToOne(() => RegionModel, (region) => region.id)
   region_id: RegionModel;
 

--- a/backend/src/users/entity/users.entity.ts
+++ b/backend/src/users/entity/users.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, OneToMany, OneToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+} from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { Exclude } from 'class-transformer';
@@ -31,8 +38,12 @@ export class UsersModel extends BaseModel {
   @Column({ name: 'phone_number', type: 'varchar', length: 20, nullable: true })
   phoneNumber: string;
 
-  @OneToOne(() => RegionModel, (region) => region.id)
-  region_id: RegionModel;
+  @ManyToOne(() => RegionModel, {
+    eager: true, // user 조회시 region도 같이 조회.
+    nullable: true,
+  })
+  @JoinColumn({ name: 'region_id' })
+  region: RegionModel;
 
   @Column({
     type: 'enum',

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UsersModel } from './entity/users.entity';
 import { Repository } from 'typeorm';
+import { RegisterUserDto } from '../auth/dto/register-user.dto';
 
 @Injectable()
 export class UsersService {
@@ -17,28 +18,22 @@ export class UsersService {
   }
 
   async createUser(
-    user: Pick<
-      UsersModel,
-      | 'username'
-      | 'email'
-      | 'password'
-      | 'profileImage'
-      | 'phoneNumber'
-      | 'region_id'
-    >,
+    user: Omit<RegisterUserDto, 'password'> & { password: string },
   ) {
+    const { username, email, region_id, ...rest } = user;
+
     const existingUser = await this.usersRepository.findOne({
-      where: [{ username: user.username }, { email: user.email }],
+      where: [{ username }, { email }],
     });
 
     if (existingUser) {
-      if (existingUser.username === user.username) {
+      if (existingUser.username === username) {
         throw new BadRequestException({
           message: 'username is already exists.',
           field: 'exists username',
         });
       }
-      if (existingUser.email === user.email) {
+      if (existingUser.email === email) {
         throw new BadRequestException({
           message: 'email is already exists.',
           field: 'exists email',
@@ -47,12 +42,10 @@ export class UsersService {
     }
 
     const newUserObject = this.usersRepository.create({
-      username: user.username,
-      email: user.email,
-      password: user.password,
-      profileImage: user.profileImage,
-      phoneNumber: user.phoneNumber,
-      region_id: user.region_id,
+      username: username,
+      email: email,
+      ...rest,
+      region_id: region_id ? { id: region_id } : null,
     });
 
     return await this.usersRepository.save(newUserObject);

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -45,7 +45,7 @@ export class UsersService {
       username: username,
       email: email,
       ...rest,
-      region_id: region_id ? { id: region_id } : null,
+      region: region_id ? { id: region_id } : null,
     });
 
     return await this.usersRepository.save(newUserObject);


### PR DESCRIPTION
# 주요 변경 사항
- BasicTokenGuard 도입: 로그인(Basic) 인증 로직을 완전히 캡슐화하여 컨트롤러에서 관련 코드를 모두 제거했습니다.
- BearerTokenGuard 리팩토링: AccessTokenGuard와 RefreshTokenGuard가 super.canActivate()를 호출하여 독립적으로 동작하도록 수정했습니다. 이를 통해 전역 가드에 대한 암묵적 의존성을 제거하여 안정성과 재사용성을 극대화했습니다.
- @Token() 데코레이터 생성: 컨트롤러에서 검증된 토큰 문자열을 선언적으로 주입받을 수 있는 방법을 제공하여, 수동 헤더 파싱 로직을 제거했습니다.
- AuthController 단순화: @UseGuards, @User, @Token을 사용하여 컨트롤러의 모든 인증 로직을 제거했습니다. 이제 컨트롤러는 비즈니스 로직 오케스트레이션에만 집중합니다.
- 비즈니스 로직 서비스로 이전: 컨트롤러의 private 헬퍼 메서드(reissueToken)를 AuthService로 이전하여 역할과 책임(SoC)을 더욱 명확하게 분리했습니다.



---


# 🛡️ 인증 시스템 시나리오 종합 검증

---

### **시나리오 1: 성공적인 로그인**

-   **요청**: `POST /auth/login` + `Authorization: Basic base64(email:password)`
-   **실행 흐름**:
    1.  `@UseGuards(BasicTokenGuard)`가 요청을 가로챕니다.
    2.  `BasicTokenGuard`는 헤더에서 `Basic` 토큰을 추출하고 디코딩하여 `email`과 `password`를 얻습니다.
    3.  `authService.authenticateWithEmailAndPassword(credentials, req.ip)`를 호출합니다.
        -   `userService.getUserByEmail`로 사용자를 조회합니다.
        -   `bcrypt.compare`로 비밀번호를 비교합니다. **(성공)**
        -   사용자의 `passwordFailedCount`를 0으로 초기화하고 DB를 업데이트합니다.
        -   인증된 `user` 객체를 반환합니다.
    4.  `BasicTokenGuard`는 반환된 `user` 객체를 `req.user`에 저장하고 `true`를 반환하여 요청을 통과시킵니다.
    5.  `AuthController`의 `postLoginEmail` 메서드가 실행됩니다.
    6.  `@User()` 데코레이터가 `req.user`에 저장된 사용자 정보를 `user` 파라미터에 주입합니다.
    7.  `authService.loginUser(user)`가 `accessToken`과 `refreshToken`을 생성하여 반환합니다.
-   ✅ **결과**: 정상적으로 토큰이 발급됩니다. 인증 로직이 가드에 완벽하게 캡슐화되어 있습니다.

---

### **시나리오 2: 로그인 실패 (비밀번호 오류)**

-   **요청**: `POST /auth/login` + 잘못된 비밀번호
-   **실행 흐름**:
    1.  `BasicTokenGuard`가 실행되고 `authService.authenticateWithEmailAndPassword`를 호출합니다.
    2.  `bcrypt.compare`로 비밀번호 비교에 **실패**합니다.
    3.  `passwordFailedCount`를 1 증가시키고 DB를 업데이트합니다.
    4.  `eventEmitter.emit('login.failed', ...)`로 로그인 실패 이벤트를 발생시킵니다.
    5.  `shouldLock` 조건을 확인하고, 계정이 잠기지 않았다면 `UnauthorizedException('email or password is not matched.')` 예외를 발생시킵니다.
-   ✅ **결과**: `401 Unauthorized` 오류가 발생하며 요청이 차단됩니다.

---

### **시나리오 3: 로그인 실패 (계정 잠김)**

-   **요청**: `POST /auth/login` + 잠긴 계정 정보
-   **실행 흐름**:
    1.  `BasicTokenGuard`가 실행되고 `authService.authenticateWithEmailAndPassword`를 호출합니다.
    2.  `userService.getUserByEmail`로 사용자를 조회한 후, `existingUser.status === UserStatusEnum.LOCKED` 조건이 `true`가 됩니다.
    3.  `ForbiddenException('User is locked.')` 예외를 발생시킵니다.
-   ✅ **결과**: `403 Forbidden` 오류가 발생하며 요청이 차단됩니다.

---

### **시나리오 4: 성공적인 토큰 재발급 (Access Token)**

-   **요청**: `POST /auth/token/access` + `Authorization: Bearer <valid_refresh_token>`
-   **실행 흐름**:
    1.  전역 `AccessTokenGuard`가 `@IsPublic`을 보고 요청을 통과시킵니다. (이때 헤더의 토큰을 읽어 `req.tokenType`을 `'refresh'`로 설정합니다.)
    2.  `@UseGuards(RefreshTokenGuard)`가 실행됩니다.
    3.  `RefreshTokenGuard`는 `req.tokenType`이 `'refresh'`인지 확인합니다. **(성공)**
    4.  `@Token()` 데코레이터가 `req.token`에 담긴 순수한 토큰 문자열을 `token` 파라미터에 주입합니다.
    5.  `authService.reissueToken(token, false)`가 호출됩니다.
        -   `rotateToken` 메서드에서 토큰을 검증하고, 새로운 `accessToken`을 생성하여 반환합니다.
-   ✅ **결과**: 새로운 `accessToken`이 정상적으로 발급됩니다.

---

### **시나리오 5: 토큰 재발급 실패 (잘못된 토큰 타입)**

-   **요청**: `POST /auth/token/access` + `Authorization: Bearer <access_token>`
-   **실행 흐름**:
    1.  전역 `AccessTokenGuard`가 `req.tokenType`을 `'access'`로 설정하고 통과시킵니다.
    2.  `RefreshTokenGuard`가 실행됩니다.
    3.  `req.tokenType`이 `'refresh'`가 아니므로 `UnauthorizedException` 예외를 발생시킵니다.
-   ✅ **결과**: `401 Unauthorized` 오류가 발생하며, "Refresh Token is required." 메시지와 함께 요청이 차단됩니다.

---

### **시나리오 6: 보호된 API 접근 (성공)**

-   **요청**: `GET /auth/test/here` + `Authorization: Bearer <valid_access_token>`
-   **실행 흐름**:
    1.  전역 `AccessTokenGuard`가 실행됩니다. `@IsPublic`이 없으므로 인증을 시작합니다.
    2.  `BearerTokenGuard`의 로직이 토큰을 검증하고, `req.user`를 설정하며, `req.tokenType`을 `'access'`로 설정합니다.
    3.  `AccessTokenGuard`는 `req.tokenType`이 `'access'`인지 확인합니다. **(성공)**
    4.  `@User()` 데코레이터가 `req.user` 정보를 컨트롤러에 주입합니다.
-   ✅ **결과**: 정상적으로 컨트롤러가 실행되고, 인증된 사용자 정보를 활용할 수 있습니다.

---

### **시나리오 7: 보호된 API 접근 실패 (잘못된 토큰 타입)**

-   **요청**: `GET /auth/test/here` + `Authorization: Bearer <refresh_token>`
-   **실행 흐름**:
    1.  전역 `AccessTokenGuard`가 실행됩니다.
    2.  `BearerTokenGuard`의 로직이 `req.tokenType`을 `'refresh'`로 설정합니다.
    3.  `AccessTokenGuard`는 `req.tokenType`이 `'access'`가 아니므로 `UnauthorizedException('No Access Token Provided')` 예외를 발생시킵니다.
-   ✅ **결과**: `401 Unauthorized` 오류가 발생하며 요청이 차단됩니다.

---

### **시나리오 8: 공개 API 접근 (인증된 사용자)**

-   **요청**: `GET /auth/test/here2` + `Authorization: Bearer <valid_access_token>`
-   **실행 흐름**:
    1.  전역 `AccessTokenGuard`가 실행됩니다. `@IsPublic`을 발견합니다.
    2.  헤더에 토큰이 있으므로, 토큰을 검증하고 `req.user`에 사용자 정보를 설정합니다. (실패해도 오류는 발생시키지 않습니다.)
    3.  `req.isRouterPublic = true`를 설정하고 요청을 통과시킵니다.
    4.  `@User()` 데코레이터가 `req.user`에 있는 사용자 객체를 컨트롤러에 주입합니다.
-   ✅ **결과**: 정상적으로 컨트롤러가 실행되며, 로그인한 사용자에게 개인화된 정보를 보여줄 수 있습니다.

---

### **시나리오 9: 공개 API 접근 (익명 사용자)**

-   **요청**: `GET /auth/test/here2` (토큰 없음)
-   **실행 흐름**:
    1.  전역 `AccessTokenGuard`가 `@IsPublic`을 보고 요청을 통과시킵니다.
    2.  `@User()` 데코레이터가 실행됩니다.
    3.  `req.user`가 없지만, `req.isRouterPublic`이 `true`이므로 `null`을 반환합니다.
    4.  컨트롤러의 `user` 파라미터에는 `null`이 주입됩니다.
-   ✅ **결과**: 정상적으로 컨트롤러가 실행되며, 익명 사용자로 처리됩니다.