### PR TITLE
기능. 사용자 프로필 관리 및 계정 잠금 해제 기능 추가

### DIFF
--- a/backend/script/create-dummy-user.ts
+++ b/backend/script/create-dummy-user.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from '../src/app.module';
-import { AuthService } from '../src/auth/auth.service';
-import { RegisterUserDto } from '../src/auth/dto/register-user.dto';
+import { CreateUserDto } from '../src/users/dto/create-user.dto';
+import { UsersService } from '../src/users/users.service';
 
 /**
  * 50명의 더미 유저를 생성하는 스크립트
@@ -12,7 +12,7 @@ import { RegisterUserDto } from '../src/auth/dto/register-user.dto';
 async function bootstrap() {
   const app = await NestFactory.createApplicationContext(AppModule);
 
-  const authService = app.get(AuthService);
+  const usersService = app.get(UsersService);
 
   try {
     console.log('start. create dummy user...');
@@ -20,7 +20,7 @@ async function bootstrap() {
     const numberOfUsers = 50;
 
     for (let i = 1; i <= numberOfUsers; i++) {
-      const user: RegisterUserDto = {
+      const user: CreateUserDto = {
         username: `user${i}`,
         email: `user${i}@dummyUser.com`,
         password: `user${i}`,
@@ -30,7 +30,7 @@ async function bootstrap() {
         region_id: null,
       };
 
-      await authService.registerWithEmail(user);
+      await usersService.createUser(user);
       console.log(`CREATE USER: ${user.username} (${user.email})`);
     }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Post, UseGuards, Get, Req } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  UseGuards,
+  Get,
+  Req,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { IsPublic } from '../common/decorator/is-public.decorator';
 import { RefreshTokenGuard } from './guard/bearer-token.guard';
@@ -7,6 +16,7 @@ import { UsersModel } from '../users/entity/users.entity';
 import { BasicTokenGuard } from './guard/basic-token.guard';
 import { Token } from './decorator/token.decorator';
 import { Request } from 'express';
+import { UnlockAccountDto } from './dto/unlock-account.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -24,6 +34,13 @@ export class AuthController {
   @UseGuards(RefreshTokenGuard)
   async postTokenRefresh(@Token() token: string, @Req() req: Request) {
     return await this.authService.rotateRefreshToken(token, req.ip);
+  }
+
+  @Post('unlock')
+  @IsPublic()
+  @HttpCode(HttpStatus.OK)
+  async postUnlockAccount(@Body() body: UnlockAccountDto) {
+    return this.authService.unlockAccount(body);
   }
 
   //TEST API

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Post, Body, UseGuards, Get, Req } from '@nestjs/common';
+import { Controller, Post, UseGuards, Get, Req } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { RegisterUserDto } from './dto/register-user.dto';
 import { IsPublic } from '../common/decorator/is-public.decorator';
 import { RefreshTokenGuard } from './guard/bearer-token.guard';
 import { User } from '../users/decorator/user.decorator';
@@ -18,12 +17,6 @@ export class AuthController {
   @UseGuards(BasicTokenGuard)
   async postLoginEmail(@User() user: UsersModel) {
     return await this.authService.loginUser(user);
-  }
-
-  @Post('users')
-  @IsPublic()
-  async postRegister(@Body() registerUserDto: RegisterUserDto) {
-    return await this.authService.registerWithEmail(registerUserDto);
   }
 
   @Post('token/refresh')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
@@ -9,7 +9,7 @@ import { RefreshTokenModel } from './entity/refresh-token.entity';
 
 @Module({
   imports: [
-    UsersModule,
+    forwardRef(() => UsersModule),
     JwtModule.register({}),
     TypeOrmModule.forFeature([RefreshTokenModel]),
   ],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -90,6 +90,14 @@ export class AuthService {
       });
     }
 
+    if (existingUser.status === UserStatusEnum.SUSPENDED) {
+      throw new ForbiddenException({
+        message:
+          'This account has been suspended. Please contact customer support.',
+        errorCode: AuthErrorCode.ACCOUNT_SUSPENDED,
+      });
+    }
+
     if (existingUser.status === UserStatusEnum.DELETED) {
       // To prevent user enumeration, treat deleted users the same as non-existent ones.
       throw new UnauthorizedException({

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -7,7 +7,6 @@ import { UsersModel } from '../users/entity/users.entity';
 import { UsersService } from '../users/users.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import * as bcrypt from 'bcrypt';
-import { RegisterUserDto } from './dto/register-user.dto';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { UserStatusEnum } from '../users/const/status.const';
@@ -146,20 +145,6 @@ export class AuthService {
       message: 'Email or password does not match.',
       errorCode: AuthErrorCode.AUTHENTICATION_FAILED,
     });
-  }
-
-  async registerWithEmail(user: RegisterUserDto) {
-    const hash = await bcrypt.hash(
-      user.password,
-      parseInt(this.configService.get<string>('HASH_ROUNDS') ?? '10'),
-    );
-
-    const newUser = await this.userService.createUser({
-      ...user,
-      password: hash,
-    });
-
-    return this.loginUser(newUser);
   }
 
   async loginUser(user: Pick<UsersModel, 'email' | 'id' | 'username'>) {

--- a/backend/src/auth/const/auth-error-code.const.ts
+++ b/backend/src/auth/const/auth-error-code.const.ts
@@ -30,4 +30,15 @@ export enum AuthErrorCode {
    * For example, using an access token to refresh tokens.
    */
   INVALID_TOKEN_TYPE = 'INVALID_TOKEN_TYPE',
+  /**
+   * A general validation error for request bodies.
+   * e.g., trying to unlock an account without providing email or phone.
+   */
+  VALIDATION_FAILED = 'VALIDATION_FAILED',
+
+  /**
+   * The account is not in the required state for the operation.
+   * e.g., trying to unlock an account that is not locked.
+   */
+  ACCOUNT_STATE_INVALID = 'ACCOUNT_STATE_INVALID',
 }

--- a/backend/src/auth/const/auth-error-code.const.ts
+++ b/backend/src/auth/const/auth-error-code.const.ts
@@ -1,0 +1,27 @@
+export enum AuthErrorCode {
+  /**
+   * A generic authentication failure for invalid credentials.
+   * It is recommended to use this for standard login failures (wrong email/password)
+   * to avoid providing specific details to potential attackers.
+   */
+  AUTHENTICATION_FAILED = 'AUTHENTICATION_FAILED',
+
+  /**
+   * The account is locked due to multiple failed login attempts.
+   * The client can use this code to display a specific message
+   * or guide the user to a password reset flow.
+   */
+  ACCOUNT_LOCKED = 'ACCOUNT_LOCKED',
+
+  /**
+   * The provided token is invalid, expired, or malformed.
+   * This is a general-purpose error for any token validation failure.
+   */
+  INVALID_TOKEN = 'INVALID_TOKEN',
+
+  /**
+   * The wrong type of token was used for an operation.
+   * For example, using an access token to refresh tokens.
+   */
+  INVALID_TOKEN_TYPE = 'INVALID_TOKEN_TYPE',
+}

--- a/backend/src/auth/const/auth-error-code.const.ts
+++ b/backend/src/auth/const/auth-error-code.const.ts
@@ -14,6 +14,12 @@ export enum AuthErrorCode {
   ACCOUNT_LOCKED = 'ACCOUNT_LOCKED',
 
   /**
+   * The account has been temporarily suspended by an administrator.
+   * The user should contact support for resolution.
+   */
+  ACCOUNT_SUSPENDED = 'ACCOUNT_SUSPENDED',
+
+  /**
    * The provided token is invalid, expired, or malformed.
    * This is a general-purpose error for any token validation failure.
    */

--- a/backend/src/auth/dto/unlock-account.dto.ts
+++ b/backend/src/auth/dto/unlock-account.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsOptional, IsString } from 'class-validator';
+
+export class UnlockAccountDto {
+  @IsEmail()
+  @IsOptional()
+  email?: string;
+
+  @IsString()
+  @IsOptional()
+  phoneNumber?: string;
+}

--- a/backend/src/auth/guard/basic-token.guard.ts
+++ b/backend/src/auth/guard/basic-token.guard.ts
@@ -5,6 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { AuthService } from '../auth.service';
+import { AuthErrorCode } from '../const/auth-error-code.const';
 
 @Injectable()
 export class BasicTokenGuard implements CanActivate {
@@ -16,7 +17,10 @@ export class BasicTokenGuard implements CanActivate {
     const rawToken = req.headers.authorization;
 
     if (!rawToken) {
-      throw new UnauthorizedException('No Token Provided');
+      throw new UnauthorizedException({
+        message: 'No token provided.',
+        errorCode: AuthErrorCode.INVALID_TOKEN,
+      });
     }
 
     const token = this.authService.extractTokenFromHeader(rawToken, false);

--- a/backend/src/auth/guard/bearer-token.guard.ts
+++ b/backend/src/auth/guard/bearer-token.guard.ts
@@ -8,6 +8,7 @@ import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY } from '../../common/decorator/is-public.decorator';
 import { AuthService } from '../auth.service';
 import { UsersService } from '../../users/users.service';
+import { AuthErrorCode } from '../const/auth-error-code.const';
 
 @Injectable()
 export class BearerTokenGuard implements CanActivate {
@@ -54,7 +55,10 @@ export class BearerTokenGuard implements CanActivate {
     }
 
     if (!rawToken) {
-      throw new UnauthorizedException('No Token Provided');
+      throw new UnauthorizedException({
+        message: 'No token provided.',
+        errorCode: AuthErrorCode.INVALID_TOKEN,
+      });
     }
 
     try {
@@ -66,7 +70,10 @@ export class BearerTokenGuard implements CanActivate {
       req.token = token;
       req.tokenType = payload.type;
     } catch (e) {
-      throw new UnauthorizedException('Invalid Token');
+      throw new UnauthorizedException({
+        message: 'Invalid token.',
+        errorCode: AuthErrorCode.INVALID_TOKEN,
+      });
     }
 
     return true;
@@ -85,7 +92,10 @@ export class AccessTokenGuard extends BearerTokenGuard {
     }
 
     if (req.tokenType !== 'access') {
-      throw new UnauthorizedException('No Access Token Provided');
+      throw new UnauthorizedException({
+        message: 'An access token must be provided.',
+        errorCode: AuthErrorCode.INVALID_TOKEN_TYPE,
+      });
     }
 
     return true;
@@ -101,7 +111,10 @@ export class RefreshTokenGuard implements CanActivate {
     const rawToken = req.headers.authorization;
 
     if (!rawToken) {
-      throw new UnauthorizedException('No Refresh Token Provided');
+      throw new UnauthorizedException({
+        message: 'A refresh token must be provided.',
+        errorCode: AuthErrorCode.INVALID_TOKEN,
+      });
     }
     const token = this.authService.extractTokenFromHeader(rawToken, true);
 

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,9 +1,16 @@
-import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
 
 /**
- * Validates the data received from the client for user registration.
+ * DTO for creating a new user.
+ * This is the base DTO for user-related data.
  */
-export class RegisterUserDto {
+export class CreateUserDto {
   /**
    * The user's name.
    * @example "user1"
@@ -25,29 +32,18 @@ export class RegisterUserDto {
    * @example "user1"
    */
   @IsString({ message: 'Password must be a string.' })
+  @MinLength(8, { message: 'Password must be at least 8 characters long.' })
   @IsNotEmpty({ message: 'Password is required.' })
   password: string;
 
-  /**
-   * The URL of the user's profile image (optional).
-   * @example "/images/profile.jpg"
-   */
   @IsString({ message: 'Profile image URL must be a string.' })
   @IsOptional()
   profileImage?: string;
 
-  /**
-   * The user's phone number (optional).
-   * @example "010-1234-5678"
-   */
   @IsString({ message: 'Phone number must be a string.' })
   @IsOptional()
   phoneNumber?: string;
 
-  /**
-   * The ID of the user's region (optional).
-   * @example "-"
-   */
   @IsString({ message: 'Region ID must be a string.' })
   @IsOptional()
   region_id?: string;

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { RegisterUserDto } from '../../auth/dto/register-user.dto';
+
+export class UpdateUserDto extends PartialType(RegisterUserDto) {}

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,4 +1,9 @@
-import { PartialType } from '@nestjs/swagger';
-import { RegisterUserDto } from '../../auth/dto/register-user.dto';
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { CreateUserDto } from './create-user.dto';
 
-export class UpdateUserDto extends PartialType(RegisterUserDto) {}
+// We use OmitType to exclude fields that should not be updated via this endpoint.
+// - Email is a unique identifier and changing it requires a more secure process.
+// - Password updates should have their own dedicated, secure endpoint.
+export class UpdateUserDto extends PartialType(
+  OmitType(CreateUserDto, ['email', 'password'] as const),
+) {}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -5,15 +5,22 @@ import {
   HttpCode,
   HttpStatus,
   Patch,
+  Post,
 } from '@nestjs/common';
 import { User } from './decorator/user.decorator';
 import { UsersModel } from './entity/users.entity';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UsersService } from './users.service';
+import { IsPublic } from '../common/decorator/is-public.decorator';
+import { CreateUserDto } from './dto/create-user.dto';
+import { AuthService } from '../auth/auth.service';
 
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
 
   @Get('me')
   async getMyProfile(@User() user: UsersModel) {
@@ -27,6 +34,15 @@ export class UsersController {
     @Body() body: UpdateUserDto,
   ): Promise<{ message: string }> {
     await this.usersService.updateUser(userId, body);
-    return { message: 'userProfile updated successfully.' };
+    return { message: 'Your profile has been updated successfully.' };
+  }
+
+  @Post()
+  @IsPublic()
+  async postUser(@Body() body: CreateUserDto) {
+    const newUser = await this.usersService.createUser(body);
+
+    // After successful registration, log the new user in immediately
+    return this.authService.loginUser(newUser);
   }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,6 +1,32 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Patch,
+} from '@nestjs/common';
+import { User } from './decorator/user.decorator';
+import { UsersModel } from './entity/users.entity';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UsersService } from './users.service';
 
 @Controller('users')
 export class UsersController {
-  constructor() {}
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  async getMyProfile(@User() user: UsersModel) {
+    return user;
+  }
+
+  @Patch('me')
+  @HttpCode(HttpStatus.OK)
+  async patchMyProfile(
+    @User('id') userId: string,
+    @Body() body: UpdateUserDto,
+  ): Promise<{ message: string }> {
+    await this.usersService.updateUser(userId, body);
+    return { message: 'userProfile updated successfully.' };
+  }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,11 +1,12 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModel } from './entity/users.entity';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UsersModel])],
+  imports: [TypeOrmModule.forFeature([UsersModel]), forwardRef(() => AuthModule)],
   exports: [UsersService],
   controllers: [UsersController],
   providers: [UsersService],

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -61,4 +61,10 @@ export class UsersService {
   async updateUser(userId: string, dto: Partial<UsersModel>) {
     await this.usersRepository.update(userId, dto);
   }
+
+  async getUserByPhoneNumber(phoneNumber: string): Promise<UsersModel | null> {
+    return this.usersRepository.findOne({
+      where: { phoneNumber },
+    });
+  }
 }


### PR DESCRIPTION
# 주요 변경 사항 (Key Changes)
1. 👤 사용자 프로필 관리 기능 (api/users/me)
- GET api/users/me: 현재 로그인된 사용자가 자신의 전체 프로필 정보를 조회할 수 있는 API를 추가했습니다.
- PATCH api/users/me: 사용자가 자신의 프로필 정보(예: 닉네임, 전화번호 등)를 직접 수정할 수 있는 API를 추가했습니다.
2. 🔑 계정 잠금 해제 기능 (api/auth/unlock)
- POST api/auth/unlock: 비밀번호를 5회 이상 잘못 입력하여 잠긴 계정을 사용자가 직접 해제할 수 있는 공개(Public) API를 추가했습니다.
- 간단한 본인 인증: 사용자는 가입 시 등록한 이메일 또는 전화번호를 요청 본문에 담아 보내는 것만으로 간단하게 본인임을 확인하고 계정 잠금을 해제할 수 있습니다.
- 상태 초기화: 잠금 해제에 성공하면, 해당 계정의 status는 ACTIVE로 변경되고, passwordFailedCount는 0으로 초기화됩니다.
3. 🚨 에러 처리 개선
- 계정 잠금 해제 과정에서 발생할 수 있는 다양한 예외 상황(예: 입력값 누락, 이미 잠금 해제된 계정)에 대응하기 위해 AuthErrorCode에 VALIDATION_FAILED, ACCOUNT_STATE_INVALID 등을 추가했습니다.
- 이를 통해 클라이언트는 일관된  { message, errorCode } 형식의 에러 응답을 받아 상황에 맞는 명확한 피드백을 사용자에게 보여줄 수 있습니다.
4. 🏗️ API 엔드포인트 구조 개선
- 회원가입 경로 변경: 기존에 api/auth 경로에 있던 회원가입(Registration) 기능을 **POST api/users**로 이동하여 RESTful 원칙에 더 부합하도록 구조를 개선했습니다. 이제 api/auth 모듈은 인증(로그인, 토큰)에만 집중하고, api/users 모듈은 사용자 리소스 생성 및 관리를 책임집니다.