### PR TITLE
기능. 지역 필터링 & isOwner 플래그 추가

### DIFF
--- a/backend/src/product/dto/get-product.dto.ts
+++ b/backend/src/product/dto/get-product.dto.ts
@@ -16,12 +16,16 @@ import {
 } from '../const/product.const';
 import { Type } from 'class-transformer';
 
-// TODO 지역 검색 추가
 export class GetProductDto extends PageDto {
   @ApiProperty({ description: '카테고리 ID' })
   @IsOptional()
   @IsUUID()
   readonly categoryId?: string;
+
+  @ApiProperty({ description: '지역 ID' })
+  @IsOptional()
+  @IsUUID()
+  readonly regionId?: string;
 
   @ApiProperty({ description: '제품 상태' })
   @IsOptional()

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -59,9 +59,15 @@ export class ProductController {
   }
 
   @ApiOperation({ description: '상품 상세 조회' })
+  @IsPublic()
   @Get('/:productId')
-  async getProduct(@Param('productId') productId: string) {
-    return await this.productService.getProduct(productId);
+  async getProduct(
+    @Param('productId') productId: string,
+    @User('id') userId?: string,
+  ) {
+    const product = await this.productService.getProduct(productId, userId);
+    console.log(product);
+    return product;
   }
 
   @ApiOperation({ description: '상품 등록' })

--- a/backend/src/product/product.module.ts
+++ b/backend/src/product/product.module.ts
@@ -5,9 +5,14 @@ import { ProductController } from './product.controller';
 import { ProductService } from './product.service';
 import { UsersModule } from '../users/users.module';
 import { AuthModule } from '../auth/auth.module';
+import { RegionModel } from '../common/entity/region.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ProductModel]), UsersModule, AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([ProductModel, RegionModel]),
+    UsersModule,
+    AuthModule,
+  ],
   controllers: [ProductController],
   providers: [ProductService],
   exports: [ProductService],

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -113,7 +113,7 @@ export class ProductService {
     };
   }
 
-  async getProduct(productId: string): Promise<ProductModel> {
+  async getProduct(productId: string, userId?: string): Promise<any> {
     const product = await this.productRepository.findOne({
       where: { id: productId },
       relations: ['author', 'category', 'region'],
@@ -123,7 +123,17 @@ export class ProductService {
       throw new NotFoundException('해당 상품을 찾을 수 없습니다.');
     }
 
-    return product;
+    if (product.author.id === userId) {
+      return {
+        ...product,
+        isOwner: true,
+      };
+    }
+
+    return {
+      ...product,
+      isOwner: false,
+    };
   }
 
   async getMySales(user: UsersModel): Promise<ProductModel[]> {


### PR DESCRIPTION
##  변경사항 요약

### 1. 상품 조회: 지역(region) 필터링 기능 추가
- `GetProductDto`에 `regionId?: string` 필드 추가 (UUID, optional, Swagger 문서화)
- `getAllProducts` 메서드에서 상위 지역의 `regionId`가 전달되면 해당 지역과 하위 지역까지 모두 포함하여 필터링 적용

### 2. 상품 상세 조회: `isOwner` 플래그 추가
- `ProductService.getProduct`에서 `userId`가 `author.id`와 일치하는지 확인 후 일치하면 `isOwner = true` 플래그 추가 반환, 일치하지 않으면 `isOwner = false` 플래그 반환

---

##  예시

#### 요청 (Product 목록 조회, 지역 필터링)
```ts
GET /products?regionId=123e4567-e89b-12d3-a456-426614174000&limit=10

// 응답 예시
{
  "items": [
    {
      "id": "abc123",
      "name": "상품 A",
      "region": { "id": "123e4567-e89b-12d3-a456-426614174000", "name": "서울" },
      // ...
    },
    // ...
  ],
  "cursor": null
}
````

#### 요청 (상품 상세 + `isOwner`)

```ts
GET /products/abc123
(headers에 토큰 포함, userId가 author.id와 같을 때)

// 응답 예시
{
  "id": "abc123",
  "name": "상품 A",
  "author": { "id": "user1", "name": "판매자1" },
  "region": { "id": "123e4567-e89b-12d3-a456-426614174000", "name": "서울" },
  "isOwner": true
}
```

---

## 참고

* 지역 필터링: 상위 지역 선택 시 해당 지역 + 하위 지역까지 모두 반영되어 조회됨
* `isOwner`: 로그인한 사용자 기준으로 본인이 작성한 상품인 경우만 `true`