### PR TITLE
기능. Refresh Token을 이용한 보안 로그아웃 기능 구현

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -29,6 +29,14 @@ export class AuthController {
     return await this.authService.loginUser(user);
   }
 
+  @Post('logout')
+  @IsPublic()
+  @UseGuards(RefreshTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async postLogout(@Token() token: string) {
+    return this.authService.logout(token);
+  }
+
   @Post('token/refresh')
   @IsPublic()
   @UseGuards(RefreshTokenGuard)
@@ -48,14 +56,6 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async postVerifyUnlock(@Body() body: VerifyUnlockDto, @Ip() ip: string) {
     return this.authService.verifyAndUnlockAccount(body, ip);
-  }
-
-  @Post('logout')
-  @IsPublic()
-  @UseGuards(RefreshTokenGuard)
-  @HttpCode(HttpStatus.OK)
-  async postLogout(@Token() token: string) {
-    return this.authService.logout(token);
   }
 
   //TEST API

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -50,6 +50,14 @@ export class AuthController {
     return this.authService.verifyAndUnlockAccount(body, ip);
   }
 
+  @Post('logout')
+  @IsPublic()
+  @UseGuards(RefreshTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async postLogout(@Token() token: string) {
+    return this.authService.logout(token);
+  }
+
   //TEST API
 
   @Get('test/here')

--- a/backend/src/mail/mail.listener.ts
+++ b/backend/src/mail/mail.listener.ts
@@ -4,12 +4,12 @@ import { MailService } from './mail.service';
 import { OnEvent } from '@nestjs/event-emitter';
 
 interface UserUnlockRequestPayload {
-  user: Pick<UsersModel, 'email' | 'username'>;
+  user: Pick<UsersModel, 'id' | 'email' | 'username'>;
   verificationCode: string;
 }
 
 interface UserPasswordResetPayload {
-  user: Pick<UsersModel, 'email' | 'username'>;
+  user: Pick<UsersModel, 'id' | 'email' | 'username'>;
   temporaryPassword: string;
 }
 

--- a/backend/src/mail/mail.module.ts
+++ b/backend/src/mail/mail.module.ts
@@ -12,7 +12,7 @@ import { MailListener } from './mail.listener';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const fromName = configService.get<string>('MAIL_FROM');
+        const fromName = configService.get<string>('APP_NAME', 'SellerRe');
         const fromEmail = configService.get<string>('MAIL_USER');
 
         const templateDir = path.join(__dirname, '..', '..', 'templates');

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -12,50 +12,45 @@ export class MailService {
   ) {}
 
   async sendAccountUnlockVerification(
-    user: Pick<UsersModel, 'email' | 'username'>,
+    user: Pick<UsersModel, 'id' | 'email' | 'username'>,
     code: string,
   ) {
     const recipient = user.email;
     const subject = '[SellerRe] 계정 잠금 해제 인증 코드';
 
-    await this.mailerService
-      .sendMail({
+    try {
+      await this.mailerService.sendMail({
         to: recipient,
         subject,
         template: 'unlock-verification',
-        context: {
-          username: user.username,
-          code,
-        },
-      })
-      .then(() => {
-        this.eventEmitter.emit('email.sent', {
-          user,
-          recipient,
-          subject,
-          status: EmailSendStatus.SENT,
-        });
-      })
-      .catch((err) => {
-        console.error('failed to send unlock verification email', err);
-        this.eventEmitter.emit('email.sent', {
-          user,
-          recipient,
-          subject,
-          status: EmailSendStatus.FAILED,
-          errorMessage: err.message,
-        });
+        context: { username: user.username, code },
       });
+      this.eventEmitter.emit('email.sent', {
+        user,
+        recipient,
+        subject,
+        status: EmailSendStatus.SENT,
+      });
+    } catch (err) {
+      console.error('failed to send unlock verification email', err);
+      this.eventEmitter.emit('email.sent', {
+        user,
+        recipient,
+        subject,
+        status: EmailSendStatus.FAILED,
+        errorMessage: err.message,
+      });
+    }
   }
 
   async sendPasswordResetNotification(
-    user: Pick<UsersModel, 'email' | 'username'>,
+    user: Pick<UsersModel, 'id' | 'email' | 'username'>,
     temporaryPassword: string,
   ) {
     const recipient = user.email;
     const subject = '[SellerRe] 비밀번호가 초기화되었습니다.';
-    await this.mailerService
-      .sendMail({
+    try {
+      await this.mailerService.sendMail({
         to: recipient,
         subject,
         template: 'password-reset',
@@ -63,24 +58,22 @@ export class MailService {
           username: user.username,
           password: temporaryPassword,
         },
-      })
-      .then(() => {
-        this.eventEmitter.emit('email.sent', {
-          user,
-          recipient,
-          subject,
-          status: EmailSendStatus.SENT,
-        });
-      })
-      .catch((err) => {
-        console.error('failed to send password reset notification email', err);
-        this.eventEmitter.emit('email.sent', {
-          user,
-          recipient,
-          subject,
-          status: EmailSendStatus.FAILED,
-          errorMessage: err.message,
-        });
       });
+      this.eventEmitter.emit('email.sent', {
+        user,
+        recipient,
+        subject,
+        status: EmailSendStatus.SENT,
+      });
+    } catch (err) {
+      console.error('failed to send password reset notification email', err);
+      this.eventEmitter.emit('email.sent', {
+        user,
+        recipient,
+        subject,
+        status: EmailSendStatus.FAILED,
+        errorMessage: err.message,
+      });
+    }
   }
 }

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -3,74 +3,71 @@ import { MailerService } from '@nestjs-modules/mailer';
 import { UsersModel } from '../users/entity/users.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { EmailSendStatus } from '../logs/const/email-send-status.const';
+import { ConfigService } from '@nestjs/config';
+import { ISendMailOptions } from '@nestjs-modules/mailer/dist/interfaces/send-mail-options.interface';
 
 @Injectable()
 export class MailService {
+  private readonly appName: string;
+
   constructor(
     private readonly mailerService: MailerService,
     private readonly eventEmitter: EventEmitter2,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.appName = this.configService.get<string>('APP_NAME', 'Seller_Re');
+  }
 
   async sendAccountUnlockVerification(
     user: Pick<UsersModel, 'id' | 'email' | 'username'>,
     code: string,
   ) {
-    const recipient = user.email;
-    const subject = '[SellerRe] 계정 잠금 해제 인증 코드';
-
-    try {
-      await this.mailerService.sendMail({
-        to: recipient,
-        subject,
-        template: 'unlock-verification',
-        context: { username: user.username, code },
-      });
-      this.eventEmitter.emit('email.sent', {
-        user,
-        recipient,
-        subject,
-        status: EmailSendStatus.SENT,
-      });
-    } catch (err) {
-      console.error('failed to send unlock verification email', err);
-      this.eventEmitter.emit('email.sent', {
-        user,
-        recipient,
-        subject,
-        status: EmailSendStatus.FAILED,
-        errorMessage: err.message,
-      });
-    }
+    const subject = `[${this.appName}] 계정 잠금 해제 인증 코드`;
+    const mailOptions: ISendMailOptions = {
+      to: user.email,
+      subject,
+      template: 'unlock-verification',
+      context: { username: user.username, code },
+    };
+    await this.sendMailWithLogging(mailOptions, user, 'unlock verification');
   }
 
   async sendPasswordResetNotification(
     user: Pick<UsersModel, 'id' | 'email' | 'username'>,
     temporaryPassword: string,
   ) {
-    const recipient = user.email;
-    const subject = '[SellerRe] 비밀번호가 초기화되었습니다.';
+    const subject = `[${this.appName}] 비밀번호가 초기화되었습니다.`;
+    const mailOptions: ISendMailOptions = {
+      to: user.email,
+      subject,
+      template: 'password-reset',
+      context: {
+        username: user.username,
+        password: temporaryPassword,
+      },
+    };
+    await this.sendMailWithLogging(mailOptions, user, 'password reset');
+  }
+
+  private async sendMailWithLogging(
+    mailOptions: ISendMailOptions,
+    user: Pick<UsersModel, 'id' | 'email' | 'username'>,
+    logContext: string,
+  ) {
     try {
-      await this.mailerService.sendMail({
-        to: recipient,
-        subject,
-        template: 'password-reset',
-        context: {
-          username: user.username,
-          password: temporaryPassword,
-        },
-      });
+      await this.mailerService.sendMail(mailOptions);
       this.eventEmitter.emit('email.sent', {
         user,
-        recipient,
-        subject,
+        recipient: mailOptions.to,
+        subject: mailOptions.subject,
         status: EmailSendStatus.SENT,
       });
     } catch (err) {
-      console.error('failed to send password reset notification email', err);
+      console.error(`failed to send ${logContext} email`, err);
       this.eventEmitter.emit('email.sent', {
         user,
-        recipient,
-        subject,
+        recipient: mailOptions.to,
+        subject: mailOptions.subject,
         status: EmailSendStatus.FAILED,
         errorMessage: err.message,
       });


### PR DESCRIPTION
## 📑 개요

본 PR은 사용자가 자신의 세션을 안전하게 종료할 수 있도록 서버 측 로그아웃 기능을 구현합니다. 이를 통해 클라이언트 측에서 토큰을 삭제하는 것뿐만 아니라, 서버에서도 해당 Refresh Token을 명시적으로 무효화하여 보안을 강화합니다.

---

## 🔑 주요 변경 사항 (Key Changes)

-   **`POST /api/auth/logout` 엔드포인트 추가**
    -   `AuthController`에 새로운 로그아웃 엔드포인트를 추가했습니다.
    -   `@IsPublic()`과 `@UseGuards(RefreshTokenGuard)`를 함께 사용하여, Access Token의 만료 여부와 관계없이 오직 유효한 Refresh Token을 가진 요청만 처리하도록 설계했습니다.

-   **Refresh Token 폐기 로직 구현**
    -   `AuthService`에 `logout` 메서드를 구현했습니다.
    -   요청받은 Refresh Token의 `jti` (JWT ID)를 이용해 데이터베이스에서 해당 토큰을 찾습니다.
    -   해당 토큰의 `isRevoked` 필드를 `true`로 업데이트하여, 더 이상 새로운 Access Token을 발급받는 데 사용할 수 없도록 폐기합니다.

-   **멱등성(Idempotency) 보장**
    -   이미 로그아웃 처리되었거나 유효하지 않은 토큰으로 로그아웃을 재시도하더라도, 에러를 반환하는 대신 성공 메시지를 반환하도록 처리했습니다. 이는 클라이언트 측의 경험을 향상시키고, 네트워크 오류 등으로 인한 중복 요청에 대해 안정적으로 대응할 수 있게 합니다.

---

## 📋 시나리오 (Scenarios)

1.  **로그인**: `POST /api/auth/login`으로 로그인하여 `accessToken`과 `refreshToken`을 발급받습니다.
2.  **정상 로그아웃**:
    -   `Authorization: Bearer <refreshToken>` 헤더에 발급받은 `refreshToken`을 담아 `POST /api/auth/logout`을 요청합니다.
    -   `200 OK` 상태 코드와 함께 성공 메시지가 반환되는지 확인합니다.
    -   데이터베이스의 `refresh_token_model` 테이블에서 해당 토큰의 `isRevoked` 컬럼이 `true`로 변경되었는지 확인합니다.
3.  **폐기된 토큰 재사용 시도 (보안 검증)**:
    -   **방금 로그아웃에 사용했던 `refreshToken`**으로 `POST /api/auth/token/refresh`를 다시 요청합니다.
    -   서버가 `rotateRefreshToken` 로직에서 `isRevoked`가 `true`인 것을 감지하고, 비정상 접근으로 간주하여 `401 Unauthorized` 에러를 반환하는지 확인합니다.
    -   이때, 해당 사용자의 모든 활성 토큰이 폐기(`revokeAllTokensForUser` 호출)되는지도 확인하면 더욱 좋습니다.
