### PR TITLE
수정. 조회수 & 찜 로직 수정

### DIFF
--- a/backend/src/likes/likes.service.ts
+++ b/backend/src/likes/likes.service.ts
@@ -88,7 +88,7 @@ export class LikesService {
     });
 
     // 상품의 likesCount 1 증가
-    await this.productRepository.increment({ id: productId }, 'likeCount', 1);
+    await this.productRepository.increment({ id: productId }, 'likesCount', 1);
 
     return `${productId} 찜 성공`;
   }
@@ -108,7 +108,7 @@ export class LikesService {
     });
 
     // 상품의 likesCount 1 감소
-    await this.productRepository.decrement({ id: productId }, 'likeCount', 1);
+    await this.productRepository.decrement({ id: productId }, 'likesCount', 1);
 
     return `${productId} 찜 삭제 성공`;
   }

--- a/backend/src/likes/likes.service.ts
+++ b/backend/src/likes/likes.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { LikeModel } from './entity/like.entity';
 import { PageDto } from '../common/dto/page.dto';
 import { ProductModel } from '../product/entity/product.entity';
+import { Transactional } from 'typeorm-transactional';
 
 @Injectable()
 export class LikesService {
@@ -71,6 +72,7 @@ export class LikesService {
     };
   }
 
+  @Transactional()
   async createLike(productId: string, userId: string): Promise<string> {
     // 특정 사용자가 특정 상품을 찜했는지 확인
     const like = await this.likeRepository.findOne({
@@ -85,9 +87,13 @@ export class LikesService {
       product: { id: productId },
     });
 
+    // 상품의 likesCount 1 증가
+    await this.productRepository.increment({ id: productId }, 'likeCount', 1);
+
     return `${productId} 찜 성공`;
   }
 
+  @Transactional()
   async deleteLike(productId: string, userId: string): Promise<string> {
     const like = await this.likeRepository.findOne({
       where: { user: { id: userId }, product: { id: productId } },
@@ -100,6 +106,9 @@ export class LikesService {
       user: { id: userId },
       product: { id: productId },
     });
+
+    // 상품의 likesCount 1 감소
+    await this.productRepository.decrement({ id: productId }, 'likeCount', 1);
 
     return `${productId} 찜 삭제 성공`;
   }

--- a/backend/src/product/entity/product.entity.ts
+++ b/backend/src/product/entity/product.entity.ts
@@ -52,7 +52,7 @@ export class ProductModel extends BaseModel {
   views: number; // 조회수
 
   @Column({ default: 0 })
-  favoriteCount: number; // 즐겨찾기 수
+  likeCount: number; // 찜 수
 
   @OneToMany(() => ProductImageModel, (image) => image.product, {
     nullable: false,

--- a/backend/src/product/entity/product.entity.ts
+++ b/backend/src/product/entity/product.entity.ts
@@ -51,9 +51,6 @@ export class ProductModel extends BaseModel {
   @Column({ default: 0 })
   views: number; // 조회수
 
-  @Column({ default: 0 })
-  likeCount: number; // 찜 수
-
   @OneToMany(() => ProductImageModel, (image) => image.product, {
     nullable: false,
     eager: true,
@@ -62,6 +59,9 @@ export class ProductModel extends BaseModel {
 
   @OneToMany(() => LikeModel, (like) => like.product)
   likes: LikeModel[];
+
+  @Column({ default: 0 })
+  likesCount: number; // 찜 수
 
   @Column({ default: false })
   isDeleted: boolean;

--- a/backend/src/product/product.module.ts
+++ b/backend/src/product/product.module.ts
@@ -10,7 +10,6 @@ import { UploadsModule } from '../uploads/uploads.module';
 import { ProductImageModel } from '../uploads/entity/product-image.entity';
 import { LikesModule } from '../likes/likes.module';
 import { ViewCountSchedule } from './schedule/view.count.schedule';
-import { CacheModule } from '@nestjs/cache-manager';
 
 @Module({
   imports: [
@@ -19,9 +18,6 @@ import { CacheModule } from '@nestjs/cache-manager';
     AuthModule,
     UploadsModule,
     LikesModule,
-    CacheModule.register({
-      ttl: 1800, // 30분
-    }),
   ],
   controllers: [ProductController],
   providers: [ProductService, ViewCountSchedule],

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -418,8 +418,8 @@ export class ProductService {
         (await this.cacheManager.get<number>(viewCountKey)) || 0;
       await this.cacheManager.set(viewCountKey, currentViewsInCache + 1);
 
-      // 30분 동안 "봤음" 기록 남기기
-      await this.cacheManager.set(viewHistoryKey, 1, 1800);
+      // 24시간 동안 "봤음" 기록 남기기
+      await this.cacheManager.set(viewHistoryKey, 1, 86400);
 
       // Dirty List에 상품 ID 추가
       const dirtyList =

--- a/backend/src/product/schedule/view.count.schedule.ts
+++ b/backend/src/product/schedule/view.count.schedule.ts
@@ -16,7 +16,7 @@ export class ViewCountSchedule {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
-  @Cron(CronExpression.EVERY_10_MINUTES) // 10분마다 실행
+  @Cron(CronExpression.EVERY_HOUR) // 1시간마다 실행
   // @Cron(CronExpression.EVERY_MINUTE) // 테스트: 1분마다 실행
   async handleViewCount() {
     this.logger.debug('Running view count update from in-memory cache...');

--- a/backend/src/product/schedule/view.count.schedule.ts
+++ b/backend/src/product/schedule/view.count.schedule.ts
@@ -16,7 +16,7 @@ export class ViewCountSchedule {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR) // 1시간마다 실행
+  @Cron(CronExpression.EVERY_10_MINUTES) // 10분마다 실행
   // @Cron(CronExpression.EVERY_MINUTE) // 테스트: 1분마다 실행
   async handleViewCount() {
     this.logger.debug('Running view count update from in-memory cache...');


### PR DESCRIPTION
- 조회수: `views`, 찜 수: `likesCount`로 조회 가능
- 조회수 제대로 증가하지 않던 문제 수정
  - 인-메모리 캐시 ttl을 30분으로 설정했던 것을 24시간으로 수정 (24시간 이내 재조회 시 조회수 올라가지 않음.)
  - 주의사항: 인-메모리 캐시는 서버가 재시작되면 사라지므로, 스케줄러가 실행되는 10분 내에 서버가 재시작되면 DB에 조회수가 업데이트되지 않음.